### PR TITLE
Calculate missing height/width dims in more cases

### DIFF
--- a/R/fa.R
+++ b/R/fa.R
@@ -223,14 +223,16 @@ fa <- function(name,
 
 get_length_value_unit <- function(css_length) {
 
-  m_val <- gregexpr('[0-9]+', css_length)
-  value <- as.numeric(unlist(regmatches(css_length, m_val))[1])
+  if (!grepl("^[0-9]+[a-z]+$", css_length)) {
 
-  m_unit <- gregexpr('[a-z]+', css_length)
-  unit <- unlist(regmatches(css_length, m_unit))
+    stop(
+      "Values provided to `height` and `width` must have a value followed by a length unit",
+      call. = FALSE
+    )
+  }
 
   list(
-    value = value,
-    unit = unit
+    value = as.numeric(sub("[a-z]+$", "", css_length)),
+    unit = sub("^[0-9]+", "", css_length)
   )
 }

--- a/R/fa.R
+++ b/R/fa.R
@@ -120,8 +120,37 @@ fa <- function(name,
   # changing value: the width
   viewbox_value <- paste0("0 0 ", svg_list$width, " 512")
 
-  # Get the width attribute through simple calculation
-  width_attr <- paste0(round(svg_list$width / 512, 2), "em")
+  # Generate the appropriate height and width attributes based on
+  # user input and the SVG viewBox dimensions
+  if (is.null(height) && is.null(width)) {
+    # Case where height and width are not user-provided
+
+    height_attr <- "1em"
+    width_attr <- paste0(round(svg_list$width / 512, 2), "em")
+
+  } else if (!is.null(height) && is.null(width)) {
+    # Case where height is user-provided but `width` is not
+
+    dim_list <- get_length_value_unit(css_length = height)
+
+    height_attr <- height
+    width_attr <-
+      paste0(round((svg_list$width / 512) * dim_list$value, 2), dim_list$unit)
+
+  } else if (is.null(height) && !is.null(width)) {
+    # Case where width is user-provided but `height` is not
+
+    dim_list <- get_length_value_unit(css_length = width)
+
+    height_attr <-
+      paste0(round(dim_list$value / (svg_list$width / 512), 2), dim_list$unit)
+    width_attr <- width
+
+  } else {
+    # Case where both the `height` and `width` are provided
+    height_attr <- height
+    width_attr <- width
+  }
 
   extra_attrs <- ""
   title_tag <- ""
@@ -167,8 +196,8 @@ fa <- function(name,
       extra_attrs,
       "viewBox=\"", viewbox_value, "\" " ,
       "style=\"",
-      "height:", height %||% "1em", ";",
-      "width:", width %||% width_attr, ";",
+      "height:", height_attr, ";",
+      "width:", width_attr, ";",
       "vertical-align:-0.125em;",
       "margin-right:0.2em;",
       "font-size:inherit;",
@@ -190,4 +219,18 @@ fa <- function(name,
   class(svg) <- c("fontawesome", "svg", class(svg))
 
   svg
+}
+
+get_length_value_unit <- function(css_length) {
+
+  m_val <- gregexpr('[0-9]+', css_length)
+  value <- as.numeric(unlist(regmatches(css_length, m_val))[1])
+
+  m_unit <- gregexpr('[a-z]+', css_length)
+  unit <- unlist(regmatches(css_length, m_unit))
+
+  list(
+    value = value,
+    unit = unit
+  )
 }

--- a/R/fa.R
+++ b/R/fa.R
@@ -153,6 +153,11 @@ fa <- function(name,
   } else {
     # Case where both the `height` and `width` are provided
 
+    # Invoke `get_length_value_unit()` to validate
+    # the CSS length units in `height` and `width`
+    get_length_value_unit(css_length = height)
+    get_length_value_unit(css_length = width)
+
     extra_attrs <- "preserveAspectRatio=\"none\" "
 
     height_attr <- height
@@ -235,8 +240,23 @@ get_length_value_unit <- function(css_length) {
     )
   }
 
+  unit <- sub("^[0-9]+", "", css_length)
+
+  if (!(unit %in% css_length_units)) {
+    stop(
+      "The provided CSS length unit is not valid.",
+      call. = FALSE
+    )
+  }
+
   list(
     value = as.numeric(sub("[a-z]+$", "", css_length)),
-    unit = sub("^[0-9]+", "", css_length)
+    unit = unit
   )
 }
+
+css_length_units <-
+  c(
+    "cm", "mm", "in", "px", "pt", "pc", "em", "ex",
+    "ch", "rem", "vw", "vh", "vmin", "vmax", "%"
+  )

--- a/R/fa.R
+++ b/R/fa.R
@@ -116,6 +116,10 @@ fa <- function(name,
     stop("This Font Awesome icon ('", name, "') does not exist", call. = FALSE)
   }
 
+  # Initialize vectors for extra SVG attributes and for the <title> tag
+  extra_attrs <- ""
+  title_tag <- ""
+
   # Generate the viewBox value through use of the only
   # changing value: the width
   viewbox_value <- paste0("0 0 ", svg_list$width, " 512")
@@ -148,12 +152,12 @@ fa <- function(name,
 
   } else {
     # Case where both the `height` and `width` are provided
+
+    extra_attrs <- "preserveAspectRatio=\"none\" "
+
     height_attr <- height
     width_attr <- width
   }
-
-  extra_attrs <- ""
-  title_tag <- ""
 
   # Generate accessibility attributes if either of
   # the "desc" or "sem" cases are chosen
@@ -165,14 +169,13 @@ fa <- function(name,
 
   } else if (a11y == "desc") {
 
-    extra_attrs <- paste0("aria-hidden=\"true\" role=\"img\" ")
+    extra_attrs <- paste0(extra_attrs, "aria-hidden=\"true\" role=\"img\" ")
 
     if (!is.null(title)) {
       title_tag <- paste0("<title>", htmlEscape(title), "</title>")
     }
 
   } else {
-
     # The 'semantic' case
 
     if (is.null(title)) {
@@ -181,6 +184,7 @@ fa <- function(name,
 
     extra_attrs <-
       paste0(
+        extra_attrs,
         "aria-label=\"",
         htmlEscape(title, attribute = TRUE), "\" ",
         "role=\"img\" "


### PR DESCRIPTION
This PR handles mixes cases where one (but not the other) length value is provided, in which case the missing length is calculated based on the SVG viewBox aspect ratio.