### PR TITLE
Allow use of CSS lengths with decimals

### DIFF
--- a/R/fa.R
+++ b/R/fa.R
@@ -236,15 +236,16 @@ fa <- function(name,
 
 get_length_value_unit <- function(css_length) {
 
-  if (!grepl("^[0-9]+[a-z]+$", css_length)) {
+  if (!grepl("^[0-9\\.]+?[a-z]+$", css_length)) {
 
     stop(
-      "Values provided to `height` and `width` must have a value followed by a length unit",
+      "Values provided to `height` and `width` must have a value ",
+      "followed by a length unit.",
       call. = FALSE
     )
   }
 
-  unit <- sub("^[0-9]+", "", css_length)
+  unit <- gsub("[0-9\\.]+?", "", css_length)
 
   if (!(unit %in% css_length_units)) {
     stop(
@@ -254,7 +255,7 @@ get_length_value_unit <- function(css_length) {
   }
 
   list(
-    value = as.numeric(sub("[a-z]+$", "", css_length)),
+    value = as.numeric(gsub("[a-z]+$", "", css_length)),
     unit = unit
   )
 }

--- a/R/fa.R
+++ b/R/fa.R
@@ -238,7 +238,7 @@ fa <- function(name,
 
 get_length_value_unit <- function(css_length) {
 
-  if (!grepl("^[0-9\\.]+?[a-z]+$", css_length)) {
+  if (!grepl("^[0-9\\.]+[a-z]+$", css_length)) {
 
     stop(
       "Values provided to `height` and `width` must have a value ",

--- a/R/fa.R
+++ b/R/fa.R
@@ -134,22 +134,24 @@ fa <- function(name,
     width_attr <- paste0(round(svg_list$width / 512, 2), "em")
 
   } else if (!is.null(height) && is.null(width)) {
-    # Case where height is user-provided but `width` is not
+
+    # Case where `height` is user-provided but `width` is not
 
     dim_list <- get_length_value_unit(css_length = height)
 
-    height_attr <- height
+    height_attr <- paste0(dim_list$value, dim_list$unit)
     width_attr <-
       paste0(round((svg_list$width / 512) * dim_list$value, 2), dim_list$unit)
 
   } else if (is.null(height) && !is.null(width)) {
-    # Case where width is user-provided but `height` is not
+
+    # Case where `width` is user-provided but `height` is not
 
     dim_list <- get_length_value_unit(css_length = width)
 
     height_attr <-
       paste0(round(dim_list$value / (svg_list$width / 512), 2), dim_list$unit)
-    width_attr <- width
+    width_attr <- paste0(dim_list$value, dim_list$unit)
 
   } else {
     # Case where both the `height` and `width` are provided

--- a/R/fa.R
+++ b/R/fa.R
@@ -238,7 +238,7 @@ fa <- function(name,
 
 get_length_value_unit <- function(css_length) {
 
-  if (!grepl("^[0-9\\.]+[a-z]+$", css_length)) {
+  if (!grepl("^^[0-9]*\\.?[0-9]+[a-z]+$", css_length)) {
 
     stop(
       "Values provided to `height` and `width` must have a numerical value ",

--- a/R/fa.R
+++ b/R/fa.R
@@ -256,18 +256,8 @@ get_length_value_unit <- function(css_length) {
     )
   }
 
-  value <- gsub("[a-z]+$", "", css_length)
-
-  if (value == ".") {
-
-    stop(
-      "The numerical portion of `height` and `width` must be a valid number.",
-      call. = FALSE
-    )
-  }
-
   list(
-    value = as.numeric(value),
+    value = as.numeric(gsub("[a-z]+$", "", css_length)),
     unit = unit
   )
 }

--- a/R/fa.R
+++ b/R/fa.R
@@ -256,8 +256,18 @@ get_length_value_unit <- function(css_length) {
     )
   }
 
+  value <- gsub("[a-z]+$", "", css_length)
+
+  if (value == ".") {
+
+    stop(
+      "The numerical portion of `height` and `width` must be a valid number.",
+      call. = FALSE
+    )
+  }
+
   list(
-    value = as.numeric(gsub("[a-z]+$", "", css_length)),
+    value = as.numeric(value),
     unit = unit
   )
 }

--- a/R/fa.R
+++ b/R/fa.R
@@ -241,7 +241,7 @@ get_length_value_unit <- function(css_length) {
   if (!grepl("^[0-9\\.]+[a-z]+$", css_length)) {
 
     stop(
-      "Values provided to `height` and `width` must have a value ",
+      "Values provided to `height` and `width` must have a numerical value ",
       "followed by a length unit.",
       call. = FALSE
     )

--- a/tests/testthat/test-fa_icon.R
+++ b/tests/testthat/test-fa_icon.R
@@ -62,6 +62,24 @@ test_that("inserting attributes and styles works for FA icons", {
     as.character(fa(name = "file", width = "1em")),
     "width:1em;"
   )
+  # Expect that fractional width values are rendered properly
+  expect_match(
+    as.character(fa(name = "file", width = "0.75em")),
+    "width:0.75em;"
+  )
+  expect_match(
+    as.character(fa(name = "file", width = ".75em")),
+    "width:0.75em;"
+  )
+  expect_match(
+    as.character(fa(name = "file", width = "1.em")),
+    "width:1em;"
+  )
+  expect_match(
+    as.character(fa(name = "file", width = ".756789em")),
+    "width:0.756789em;"
+  )
+
   # Expect a default width of 0.75em
   expect_match(
     as.character(fa(name = "file")),

--- a/tests/testthat/test-fa_icon.R
+++ b/tests/testthat/test-fa_icon.R
@@ -73,10 +73,7 @@ test_that("inserting attributes and styles works for FA icons", {
     as.character(fa(name = "file", width = ".75em")),
     "width:0.75em;"
   )
-  expect_match(
-    as.character(fa(name = "file", width = "1.em")),
-    "width:1em;"
-  )
+
   expect_match(
     as.character(fa(name = "file", width = ".756789em")),
     "width:0.756789em;"
@@ -98,6 +95,11 @@ test_that("inserting attributes and styles works for FA icons", {
   # Expect that supplying an empty string will result in an error
   expect_error(
     as.character(fa(name = "file", width = ""))
+  )
+
+  # Expect that ending with a dot should result in an error
+  expect_error(
+    as.character(fa(name = "file", width = "1.em"))
   )
 
   # Expect that supplying a dot for the width value will result in an error

--- a/tests/testthat/test-fa_icon.R
+++ b/tests/testthat/test-fa_icon.R
@@ -51,6 +51,7 @@ test_that("inserting attributes and styles works for FA icons", {
     as.character(fa(name = "file", height = "30em")),
     "height:30em;"
   )
+
   # Expect a default height of 1em
   expect_match(
     as.character(fa(name = "file")),
@@ -62,6 +63,7 @@ test_that("inserting attributes and styles works for FA icons", {
     as.character(fa(name = "file", width = "1em")),
     "width:1em;"
   )
+
   # Expect that fractional width values are rendered properly
   expect_match(
     as.character(fa(name = "file", width = "0.75em")),
@@ -78,6 +80,29 @@ test_that("inserting attributes and styles works for FA icons", {
   expect_match(
     as.character(fa(name = "file", width = ".756789em")),
     "width:0.756789em;"
+  )
+
+  # Expect that not supplying a width value will result in an error
+  expect_error(
+    as.character(fa(name = "file", width = "em"))
+  )
+
+  # Expect that not giving a length unit will result in an error
+  expect_error(
+    as.character(fa(name = "file", width = "1"))
+  )
+  expect_error(
+    as.character(fa(name = "file", width = 1))
+  )
+
+  # Expect that supplying an empty string will result in an error
+  expect_error(
+    as.character(fa(name = "file", width = ""))
+  )
+
+  # Expect that supplying a dot for the width value will result in an error
+  expect_error(
+    as.character(fa(name = "file", width = ".em"))
   )
 
   # Expect a default width of 0.75em


### PR DESCRIPTION
This fixes a bug in the `get_length_value_unit()` util function that doesn't take into account CSS length values that have fractional parts. The regex patterns now consider the presence of a `.` in the value part. Several testthat tests were added to ensure that the changes now work with CSS lengths such as `"0.563em"`.

Fixes #73
Fixes #66