### PR TITLE
Allow use of full icon names in `fa_i()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # fontawesome (development version)
 
+* Closed #68: full icon names (e.g., `"fab fa-r-project"`) are now properly parsed and verified in the `fa_i()` function. (#77) 
+
 * Closed #66 and #73: CSS length values (supplied to the `height` or `width` options of the `fa()` function) are now correctly handled when they contain decimals. (#74) 
 
 # fontawesome 0.2.2

--- a/R/fa_i.R
+++ b/R/fa_i.R
@@ -61,10 +61,19 @@ fa_i <- function(name,
     prefix_class <- "fab"
   }
 
-  iconClass <- paste0(prefix_class, " ", prefix, "-", name)
+  if (grepl("^fa[a-z] fa-[a-z-]+$", name)) {
+    # Case where fully-qualified icon name is provided
 
-  if (!is.null(class)) {
-    iconClass <- paste(iconClass, class)
+    iconClass <- name
+
+  } else {
+    # Case where short icon name is provided
+
+    iconClass <- paste0(prefix_class, " ", prefix, "-", name)
+
+    if (!is.null(class)) {
+      iconClass <- paste(iconClass, class)
+    }
   }
 
   icon_tag <-

--- a/R/fa_i.R
+++ b/R/fa_i.R
@@ -80,7 +80,7 @@ fa_i <- function(name,
     htmltools::tags$i(
       class = iconClass,
       role = "presentation",
-      `aria-label` = paste(name, "icon"),
+      `aria-label` = paste(gsub("^fa[a-z]* fa-", "", name), "icon"),
       ...
     )
 

--- a/tests/testthat/test-fa_icon.R
+++ b/tests/testthat/test-fa_icon.R
@@ -170,9 +170,10 @@ test_that("the `fa_i()` function returns an icon object", {
   # Use a valid, fully-qualified icon name
   icon <- fa_i(name = "fab fa-r-project")
 
-  # Expect that the same icon tag is produced
+  # Expect that the same icon tag is produced with the fully-qualified
+  # name compared to the short name
   expect_equal(
-    as.character(fa_i(name = "r-project")),
+    as.character(icon),
     "<i class=\"fab fa-r-project\" role=\"presentation\" aria-label=\"r-project icon\"></i>"
   )
 })

--- a/tests/testthat/test-fa_icon.R
+++ b/tests/testthat/test-fa_icon.R
@@ -166,6 +166,15 @@ test_that("the `fa_i()` function returns an icon object", {
     as.character(icon_2),
     "<i class=\"fab fa-r-project\" role=\"presentation\" aria-label=\"r-project icon\" height=\"20px\"></i>"
   )
+
+  # Use a valid, fully-qualified icon name
+  icon <- fa_i(name = "fab fa-r-project")
+
+  # Expect that the same icon tag is produced
+  expect_equal(
+    as.character(fa_i(name = "r-project")),
+    "<i class=\"fab fa-r-project\" role=\"presentation\" aria-label=\"r-project icon\"></i>"
+  )
 })
 
 test_that("the user can quell messages in `fa_i()`", {


### PR DESCRIPTION
This is a bugfix that enables the use of fully-qualified icon names in `fa_i()`. The current documentation states that this is possible but it wasn't so until this fix.

Fixes: #68 