### PR TITLE
Check if used in knitr only. Warn and ignore in that case.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     htmltools (>= 0.5.1.1)
 Suggests:
     covr,
-    knitr,
+    knitr (>= 1.31),
     testthat,
     rsvg
 Roxygen: list(markdown = TRUE)

--- a/R/knit_print.R
+++ b/R/knit_print.R
@@ -11,8 +11,14 @@ knit_print.fontawesome <- function(x, ..., options, inline = FALSE) {
 
   # nocov start
 
-  # TODO: use `knitr::pandoc_to()` in the future
-  to <- knitr::opts_knit$get("rmarkdown.pandoc.to")
+  to <- knitr::pandoc_to()
+
+  if (is.null(to)) {
+    warning("fontawesome can be used with rmarkdown output formats only and not knitr only. ",
+            "Icon(s) will not show.",
+            call. = FALSE)
+    return(NULL)
+  }
 
   # these formats support inline svg so use next method (i.e htmltools::knit_print.html)
   if (to %in% c("html", "html4", "html5", "slidy", "revealjs", "markdown")) {


### PR DESCRIPTION
This closes #82 

Choice here is to do like unsupported format : Warn and Ignore when we detect no `knitr::pandoc_to()` formats, meaning **rmarkdown** is not used, only `knitr::knit()` directly. 

Usually, we don't know for sure the output format in that case where YAML header is not used. 

However, we could try support it if you want (for Rnw to .tex for example, or Rmd to .md). We would test `knitr::out_format()` in that case, but I am not sure how reliable this is, and it is possible that the output document after does not support our assumption. 

That is why I am thinking limiting to **rmarkdown** only seems easier and enough. 

I upgrade suggest requirement to 1.31 for `knitr::pandoc_to()` but we could keep the old way if you prefer. 



